### PR TITLE
Dont analyse empty inputs

### DIFF
--- a/src/jsMain/kotlin/main.kt
+++ b/src/jsMain/kotlin/main.kt
@@ -71,6 +71,9 @@ fun decode(tryhard: Boolean) {
     val output = document.getElementById("output") as HTMLDivElement
 
     val bytes = ByteWitch.getBytesFromInputEncoding(input.value)
+    // no point in analyzing empty bytes
+    if (bytes.size == 0) { return }
+
     val result = ByteWitch.analyze(bytes, tryhard)
 
     if(result.isNotEmpty()) {


### PR DESCRIPTION
Currently, empty inputs result in an empty `data` array. If a decoder, like `PGP` accepts such empty input as "valid", it's always displayed, though of course this is a bit pointless.

This can be seen when using either a fully empty input (type something, remove it again), an un-even hex input (`abc`) or an empty base64 string (`====`)

![image](https://github.com/user-attachments/assets/abd6aba5-bd75-4a4a-b986-81890d5aafd4)

It would of course also be nice to have some better magic bytes for PGPv1 to prevent these false positives, but parsing empty data definitely makes no sense either way and fixes this issue as well for any future decoders that also do not have magic bytes.