### PR TITLE
OPACK parser: exponential byte length field

### DIFF
--- a/src/commonMain/kotlin/decoders/Opack.kt
+++ b/src/commonMain/kotlin/decoders/Opack.kt
@@ -209,11 +209,11 @@ class OpackParser : ParseCompanion() {
                 return OPData(readBytes(bytes, length), Pair(start, lastConsumedBytePosition))
             }
             0x93 -> {
-                val length = readInt(bytes, 3, byteOrder = ByteOrder.LITTLE)
+                val length = readInt(bytes, 4, byteOrder = ByteOrder.LITTLE)
                 return OPData(readBytes(bytes, length), Pair(start, lastConsumedBytePosition))
             }
             0x94 -> {
-                val length = readInt(bytes, 4, byteOrder = ByteOrder.LITTLE)
+                val length = readInt(bytes, 8, byteOrder = ByteOrder.LITTLE)
                 return OPData(readBytes(bytes, length), Pair(start, lastConsumedBytePosition))
             }
             else -> throw Exception("Unexpected OPACK data ${bytes.hex()}")


### PR DESCRIPTION
I came across some OPACK data with a rather large bytestring and noticed that the length field also uses exponential length field sizes (so 1, 2, 4 or 8 bytes instead of 1, 2, 3, 4 bytes). I suspect this is the same for strings, but it never came up since most strings are not long enough to use the 4 bytes length field.